### PR TITLE
refactor: Extract UI components to AppUIScreen.kt

### DIFF
--- a/app/src/main/java/com/android/rokuapp/MainActivity.kt
+++ b/app/src/main/java/com/android/rokuapp/MainActivity.kt
@@ -4,25 +4,110 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil3.compose.AsyncImage
 import com.android.rokuapp.data.model.App
 import com.android.rokuapp.ui.theme.RokuAppTheme
 import com.android.rokuapp.view.AppItem
 import com.android.rokuapp.view.AppUIScreen
+import com.android.rokuapp.viewmodel.AppViewModel
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
+            val viewModel: AppViewModel = viewModel()
             RokuAppTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+
+                    // Main screen with scaffold handle errors
                     AppUIScreen(modifier = Modifier.padding(innerPadding))
+
+                    // Basic view tutorial
+                    //MainScreen2(viewModel, modifier = Modifier.padding(innerPadding))
+
+                    // MainScreen with out scaffold
+                    // MainScreen() // comment out scaffold
                 }
+            }
+        }
+    }
+}
+
+/**
+ *  View of the app without scaffold
+ */
+@Composable
+fun MainScreen(viewModel: AppViewModel = viewModel()) {
+
+    val state by viewModel.state.collectAsState()
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(top = 20.dp)
+    ) {
+        items(state.apps) { app ->
+            AppItem(app = app)
+        }
+    }
+}
+
+/**
+ * Basic view of the app
+ */
+@Composable
+fun MainScreen2(viewModel: AppViewModel, modifier: Modifier) {
+
+    val state by viewModel.state.collectAsState()
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(top = 20.dp)
+    ) {
+        items(state.apps) { app ->
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                Text(
+                    text = app.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "ID: ${app.id}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                AsyncImage(
+                    model = "https://rokumobileinterview.s3.us-west-2.amazonaws.com/" + app.imageUrl,
+                    contentDescription = app.name,
+                    modifier = Modifier.size(128.dp)
+                )
             }
         }
     }

--- a/app/src/main/java/com/android/rokuapp/MainActivity.kt
+++ b/app/src/main/java/com/android/rokuapp/MainActivity.kt
@@ -5,22 +5,14 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
-import coil3.compose.AsyncImage
 import com.android.rokuapp.data.model.App
-import com.android.rokuapp.viewmodel.AppViewModel
 import com.android.rokuapp.ui.theme.RokuAppTheme
+import com.android.rokuapp.view.AppItem
+import com.android.rokuapp.view.AppUIScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -29,129 +21,9 @@ class MainActivity : ComponentActivity() {
         setContent {
             RokuAppTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    AppScreen(modifier = Modifier.padding(innerPadding))
+                    AppUIScreen(modifier = Modifier.padding(innerPadding))
                 }
             }
-        }
-    }
-}
-
-@Composable
-fun AppScreen(
-    modifier: Modifier = Modifier,
-    viewModel: AppViewModel = viewModel()
-) {
-    val state by viewModel.state.collectAsState()
-    
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(16.dp)
-    ) {
-        Text(
-            text = "Roku Apps",
-            style = MaterialTheme.typography.headlineMedium,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
-        
-        when {
-            state.isLoading -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center
-                    ) {
-                        CircularProgressIndicator()
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Text("Loading apps...")
-                    }
-                }
-            }
-
-            state.error != null -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center
-                    ) {
-                        Text(
-                            text = "Error: ${state.error}",
-                            color = MaterialTheme.colorScheme.error,
-                            textAlign = TextAlign.Center
-                        )
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Button(onClick = { viewModel.loadApps() }) {
-                            Text("Retry")
-                        }
-                    }
-                }
-            }
-
-            state.apps.isEmpty() -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text("No apps found")
-                }
-            }
-            
-            else -> {
-                AppList(apps = state.apps)
-            }
-        }
-    }
-}
-
-@Composable
-fun AppList(apps: List<App>) {
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        items(apps) { app ->
-            AppItem(app = app)
-        }
-    }
-}
-
-@Composable
-fun AppItem(app: App) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 4.dp),
-        shape = RoundedCornerShape(8.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        ) {
-            Text(
-                text = app.name,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = "ID: ${app.id}",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            AsyncImage(
-                model = "https://rokumobileinterview.s3.us-west-2.amazonaws.com/"+app.imageUrl,
-                contentDescription = app.name,
-                modifier = Modifier.size(128.dp)
-            )
         }
     }
 }
@@ -174,6 +46,6 @@ fun AppItemPreview() {
 @Composable
 fun AppScreenPreview() {
     RokuAppTheme {
-        AppScreen()
+        AppUIScreen()
     }
 }

--- a/app/src/main/java/com/android/rokuapp/view/AppUIScreen.kt
+++ b/app/src/main/java/com/android/rokuapp/view/AppUIScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -66,7 +65,7 @@ fun AppUIScreen(
                             textAlign = TextAlign.Center
                         )
                         Spacer(modifier = Modifier.height(16.dp))
-                        Button(onClick = { viewModel.loadApps() }) {
+                        Button(onClick = { viewModel.fetchApps() }) {
                             Text("Retry")
                         }
                     }

--- a/app/src/main/java/com/android/rokuapp/view/AppUIScreen.kt
+++ b/app/src/main/java/com/android/rokuapp/view/AppUIScreen.kt
@@ -1,0 +1,127 @@
+package com.android.rokuapp.view
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil3.compose.AsyncImage
+import com.android.rokuapp.data.model.App
+import com.android.rokuapp.viewmodel.AppViewModel
+
+@Composable
+fun AppUIScreen(
+    modifier: Modifier = Modifier,
+    viewModel: AppViewModel = viewModel()
+) {
+    val state by viewModel.state.collectAsState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Roku Apps",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        when {
+            state.error != null -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        Text(
+                            text = "Error: ${state.error}",
+                            color = MaterialTheme.colorScheme.error,
+                            textAlign = TextAlign.Center
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Button(onClick = { viewModel.loadApps() }) {
+                            Text("Retry")
+                        }
+                    }
+                }
+            }
+
+            else -> {
+                AppList(apps = state.apps)
+            }
+        }
+    }
+}
+
+@Composable
+fun AppList(apps: List<App>) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(apps) { app ->
+            AppItem(app = app)
+        }
+    }
+}
+
+@Composable
+fun AppItem(app: App) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp),
+        shape = RoundedCornerShape(8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Text(
+                text = app.name,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "ID: ${app.id}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            AsyncImage(
+                model = "https://rokumobileinterview.s3.us-west-2.amazonaws.com/"+app.imageUrl,
+                contentDescription = app.name,
+                modifier = Modifier.size(128.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/android/rokuapp/view/AppUIScreenErrorLogic.kt
+++ b/app/src/main/java/com/android/rokuapp/view/AppUIScreenErrorLogic.kt
@@ -82,7 +82,7 @@ fun AppUIScreenErrorLogic(
                             textAlign = TextAlign.Center
                         )
                         Spacer(modifier = Modifier.height(16.dp))
-                        Button(onClick = { viewModel.loadApps() }) {
+                        Button(onClick = { viewModel.fetchApps() }) {
                             Text("Retry")
                         }
                     }

--- a/app/src/main/java/com/android/rokuapp/view/AppUIScreenErrorLogic.kt
+++ b/app/src/main/java/com/android/rokuapp/view/AppUIScreenErrorLogic.kt
@@ -1,0 +1,152 @@
+package com.android.rokuapp.view
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil3.compose.AsyncImage
+import com.android.rokuapp.data.model.App
+import com.android.rokuapp.viewmodel.AppViewModel
+
+@Composable
+fun AppUIScreenErrorLogic(
+    modifier: Modifier = Modifier,
+    viewModel: AppViewModel = viewModel()
+) {
+    val state by viewModel.state.collectAsState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Roku Apps",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        when {
+            state.isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        CircularProgressIndicator()
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text("Loading apps...")
+                    }
+                }
+            }
+
+            state.error != null -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        Text(
+                            text = "Error: ${state.error}",
+                            color = MaterialTheme.colorScheme.error,
+                            textAlign = TextAlign.Center
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Button(onClick = { viewModel.loadApps() }) {
+                            Text("Retry")
+                        }
+                    }
+                }
+            }
+
+            state.apps.isEmpty() -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text("No apps found")
+                }
+            }
+
+            else -> {
+                AppList1(apps = state.apps)
+            }
+        }
+    }
+}
+
+@Composable
+fun AppList1(apps: List<App>) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(apps) { app ->
+            AppItem1(app = app)
+        }
+    }
+}
+
+@Composable
+fun AppItem1(app: App) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp),
+        shape = RoundedCornerShape(8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Text(
+                text = app.name,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "ID: ${app.id}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            AsyncImage(
+                model = "https://rokumobileinterview.s3.us-west-2.amazonaws.com/" + app.imageUrl,
+                contentDescription = app.name,
+                modifier = Modifier.size(128.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/android/rokuapp/viewmodel/AppViewModel.kt
+++ b/app/src/main/java/com/android/rokuapp/viewmodel/AppViewModel.kt
@@ -20,10 +20,10 @@ class AppViewModel : ViewModel() {
     val state: StateFlow<AppState> = _state.asStateFlow()
 
     init {
-        loadApps()
+        fetchApps()
     }
 
-    fun loadApps() {
+    fun fetchApps() {
         viewModelScope.launch {
             _state.value = _state.value.copy(isLoading = true, error = null)
             try {


### PR DESCRIPTION
This commit moves UI-related composables from `MainActivity.kt` to a new file `AppUIScreen.kt` and introduces `AppUIScreenErrorLogic.kt` which includes enhanced error handling and loading states.

- **MainActivity.kt:**
    - Simplified to primarily set up the `RokuAppTheme` and `Scaffold`.
    - Now calls `AppUIScreen` composable to render the main UI.
    - Removed `AppScreen`, `AppList`, and `AppItem` composables as they are moved.
    - Updated `AppScreenPreview` to use `AppUIScreen`.

- **AppUIScreen.kt (New File):**
    - Contains the `AppUIScreen`, `AppList`, and `AppItem` composables, previously in `MainActivity.kt`.
    - `AppUIScreen` observes the `AppViewModel` state and displays either an error message with a retry button or the list of apps.
    - `AppList` displays a `LazyColumn` of `AppItem`s.
    - `AppItem` displays individual app details in a `Card`.

- **AppUIScreenErrorLogic.kt (New File):**
    - Introduced `AppUIScreenErrorLogic`, `AppList1`, and `AppItem1` composables.
    - `AppUIScreenErrorLogic` enhances the UI state handling by:
        - Displaying a `CircularProgressIndicator` and "Loading apps..." text when `state.isLoading` is true.
        - Displaying an error message and a "Retry" button when `state.error` is not null. - Displaying "No apps found" when `state.apps` is empty and not loading or in an error state. - Displaying the list of apps using `AppList1` otherwise.
    - `AppList1` and `AppItem1` are similar in structure to `AppList` and `AppItem` respectively.