### PR TITLE
refactor: Centralize BASE_URL for image loading

### DIFF
--- a/app/src/main/java/com/android/rokuapp/MainActivity.kt
+++ b/app/src/main/java/com/android/rokuapp/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.android.rokuapp.data.model.App
+import com.android.rokuapp.data.network.ApiService.Companion.BASE_URL
 import com.android.rokuapp.ui.theme.RokuAppTheme
 import com.android.rokuapp.view.AppItem
 import com.android.rokuapp.view.AppUIScreen
@@ -104,7 +105,7 @@ fun MainScreen2(viewModel: AppViewModel, modifier: Modifier) {
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 AsyncImage(
-                    model = "https://rokumobileinterview.s3.us-west-2.amazonaws.com/" + app.imageUrl,
+                    model = BASE_URL + app.imageUrl,
                     contentDescription = app.name,
                     modifier = Modifier.size(128.dp)
                 )
@@ -121,7 +122,7 @@ fun AppItemPreview() {
             app = App(
                 id = "12",
                 name = "Netflix",
-                imageUrl = "https://rokumobileinterview.s3.us-west-2.amazonaws.com/12.jpg"
+                imageUrl = BASE_URL + "12.jpg"
             )
         )
     }

--- a/app/src/main/java/com/android/rokuapp/data/network/ApiService.kt
+++ b/app/src/main/java/com/android/rokuapp/data/network/ApiService.kt
@@ -8,6 +8,10 @@ import retrofit2.http.GET
 interface ApiService {
     @GET("apps.json")
     suspend fun getApps(): ApiResponse
+
+    companion object {
+        const val BASE_URL = "https://rokumobileinterview.s3.us-west-2.amazonaws.com/"
+    }
 }
 
 @Serializable

--- a/app/src/main/java/com/android/rokuapp/data/network/Repository.kt
+++ b/app/src/main/java/com/android/rokuapp/data/network/Repository.kt
@@ -1,6 +1,7 @@
 package com.android.rokuapp.data.network
 
 import com.android.rokuapp.data.model.App
+import com.android.rokuapp.data.network.ApiService.Companion.BASE_URL
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import retrofit2.Retrofit
@@ -12,7 +13,7 @@ object Repository {
 
     private val apiService: ApiService by lazy {
         Retrofit.Builder()
-            .baseUrl("https://rokumobileinterview.s3.us-west-2.amazonaws.com/")
+            .baseUrl(BASE_URL)
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
             .create(ApiService::class.java)

--- a/app/src/main/java/com/android/rokuapp/view/AppUIScreen.kt
+++ b/app/src/main/java/com/android/rokuapp/view/AppUIScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.android.rokuapp.data.model.App
+import com.android.rokuapp.data.network.ApiService.Companion.BASE_URL
 import com.android.rokuapp.viewmodel.AppViewModel
 
 @Composable
@@ -117,7 +118,7 @@ fun AppItem(app: App) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
             AsyncImage(
-                model = "https://rokumobileinterview.s3.us-west-2.amazonaws.com/"+app.imageUrl,
+                model = BASE_URL + app.imageUrl,
                 contentDescription = app.name,
                 modifier = Modifier.size(128.dp)
             )


### PR DESCRIPTION
This commit introduces a `BASE_URL` constant in `ApiService.kt` and updates its usage across the application for constructing image URLs.

- **ApiService.kt:**
    - Added a companion object with `const val BASE_URL = "https://rokumobileinterview.s3.us-west-2.amazonaws.com/"`.
- **Repository.kt:**
    - Updated Retrofit instance to use `ApiService.BASE_URL` for its base URL.
- **MainActivity.kt & AppUIScreen.kt:**
    - Modified `AsyncImage` composable to construct image URLs by prefixing `app.imageUrl` with `ApiService.BASE_URL`.
    - Updated the preview in `MainActivity.kt` (`AppItemPreview`) to also use `ApiService.BASE_URL`.